### PR TITLE
[#SSTD-102] Switch S3 to Intelligent Tiering (SESS)

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -52,7 +52,9 @@ pg_dump_database() {
 upload_to_bucket() {
     # if the zipped backup file is larger than 50 GB add the --expected-size option
     # see https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html
-    s3 cp - "s3://$S3_BUCKET_NAME/$(date +%Y/%m/%d/backup-%H-%M-%S.sql.gz)"
+    s3 cp \
+        --storage-class "$S3_STORAGE_CLASS" \
+        - "s3://$S3_BUCKET_NAME/$(date +%Y/%m/%d/backup-%H-%M-%S.sql.gz)"
 }
 
 main() {


### PR DESCRIPTION
The `postgres-s3-backups` repository currently uses the Standard S3 storage class in `render.yaml`.
Update the configuration so that the S3 plan/storage class is set to Intelligent-Tiering for the SESS environment.

✅ Add --storage-class to `backup.sh`
✅ Add env var to [Render environment](https://dashboard.render.com/cron/crn-cksdei85vl2c73f5bre0/env)